### PR TITLE
nBytesReceived needs to be used when reading from network stream

### DIFF
--- a/Source/Ftp/FtpSocketHandler.cs
+++ b/Source/Ftp/FtpSocketHandler.cs
@@ -75,7 +75,7 @@ namespace AzureFtpServer.Ftp
 
                 while (nReceived > 0)
                 {
-                    m_theCommands.Process(abData);
+                    m_theCommands.Process(abData, nReceived);
 
                     // the Read method will block
                     nReceived = m_theSocket.GetStream().Read(abData, 0, m_nBufferSize);


### PR DESCRIPTION
Fixed a bug where reading from the network stream didn't take into account how many bytes were read into the buffer. NetworkStream.Read() won't always fill the whole buffer, so nReceived needs to be used to determine how much of the buffer has valid data. It is now passed to FtpConnectionObject where the buffer is read.

A future improvement that could optionally be made - keep the decoding logic solely inside of FtpSocketHandler and only pass FtpConnectionObject the full string message once an end-of-line is reached.

This commit also has some whitespace changes that were a result of VS auto-format document.
