### PR TITLE
Valid answer for "PASS" command after succesfull login

### DIFF
--- a/Source/Ftp/PasswordCommandHandler.cs
+++ b/Source/Ftp/PasswordCommandHandler.cs
@@ -21,7 +21,7 @@ namespace AzureFtpServer.FtpCommands
 
             if (ConnectionObject.Login(sMessage))
             {
-                return GetMessage(220, "Password ok, FTP server ready");
+                return GetMessage(230, "Password ok, FTP server ready");
             }
             else
             {


### PR DESCRIPTION
https://tools.ietf.org/html/rfc959 

220 response is not a valid response after "PASS" command.
Changed it to 230 ("User logged in, proceed. Logged out if appropriate.")